### PR TITLE
refactor: Add some changes to registration and authentication, add a test.

### DIFF
--- a/promo_code/user/serializers.py
+++ b/promo_code/user/serializers.py
@@ -82,13 +82,26 @@ class SignInSerializer(
         write_only=True,
     )
 
-    def validate(self, data):
-        email = data.get('email')
-        password = data.get('password')
+    def validate(self, attrs):
+        user = self.authenticate_user(attrs)
+
+        self.update_token_version(user)
+
+        data = super().validate(attrs)
+
+        refresh = rest_framework_simplejwt.tokens.RefreshToken(data['refresh'])
+
+        self.invalidate_previous_tokens(user, refresh['jti'])
+
+        return data
+
+    def authenticate_user(self, attrs):
+        email = attrs.get('email')
+        password = attrs.get('password')
 
         if not email or not password:
-            raise rest_framework.serializers.ValidationError(
-                {'status': 'error', 'message': 'Both fields are required.'},
+            raise rest_framework.exceptions.ValidationError(
+                {'detail': 'Both email and password are required'},
                 code='required',
             )
 
@@ -97,55 +110,26 @@ class SignInSerializer(
             email=email,
             password=password,
         )
-        if not user:
+
+        if not user or not user.is_active:
             raise rest_framework.exceptions.AuthenticationFailed(
-                {'status': 'error', 'message': 'Invalid email or password.'},
-                code='authorization',
+                {'detail': 'Invalid credentials or inactive account'},
+                code='authentication_failed',
             )
 
-        authenticate_kwargs = {
-            self.username_field: data[self.username_field],
-            'password': data['password'],
-        }
-        try:
-            authenticate_kwargs['request'] = self.context['request']
-        except KeyError:
-            pass
+        return user
 
-        self.user = django.contrib.auth.authenticate(**authenticate_kwargs)
-
-        if not getattr(self.user, 'is_active', None):
-            raise rest_framework.exceptions.AuthenticationFailed(
-                self.error_messages['no_active_account'],
-                'no_active_account',
-            )
-
-        self.user.token_version += 1
-        self.user.save()
-
-        refresh = self.get_token(self.user)
-        data = {
-            'refresh': str(refresh),
-            'access': str(refresh.access_token),
-        }
-
-        current_jti = refresh['jti']
-
-        tokens_qs = tb_models.OutstandingToken.objects.filter(
-            user=self.user,
-        )
-
-        outstanding_tokens = tokens_qs.exclude(jti=current_jti)
+    def invalidate_previous_tokens(self, user, current_jti):
+        outstanding_tokens = tb_models.OutstandingToken.objects.filter(
+            user=user,
+        ).exclude(jti=current_jti)
 
         for token in outstanding_tokens:
-            (
-                tb_models.BlacklistedToken.objects.get_or_create(
-                    token=token,
-                )
-            )
+            tb_models.BlacklistedToken.objects.get_or_create(token=token)
 
-        data['token_version'] = self.user.token_version
-        return data
+    def update_token_version(self, user):
+        user.token_version += 1
+        user.save()
 
     def get_token(self, user):
         token = super().get_token(user)

--- a/promo_code/user/tests.py
+++ b/promo_code/user/tests.py
@@ -470,12 +470,12 @@ class JWTTests(rest_framework.test.APITestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_refresh_token_invalidation_after_new_login(self):
-
         first_login_response = self.client.post(
             self.signin_url,
             self.user_data,
             format='json',
         )
+
         refresh_token_v1 = first_login_response.data['refresh']
 
         second_login_response = self.client.post(
@@ -534,21 +534,3 @@ class JWTTests(rest_framework.test.APITestCase):
             (tb_models.OutstandingToken.objects.count()),
             2,
         )
-
-    def test_token_version_increment(self):
-        response1 = self.client.post(
-            self.signin_url,
-            self.user_data,
-            format='json',
-        )
-        self.assertEqual(response1.data['token_version'], 1)
-
-        response2 = self.client.post(
-            self.signin_url,
-            self.user_data,
-            format='json',
-        )
-        self.assertEqual(response2.data['token_version'], 2)
-
-        user_ = user.models.User.objects.get(email=self.user_data['email'])
-        self.assertEqual(user_.token_version, 2)

--- a/promo_code/user/views.py
+++ b/promo_code/user/views.py
@@ -35,9 +35,11 @@ class SignUpView(
             return self.handle_validation_error()
 
         user = serializer.save()
+
         refresh = rest_framework_simplejwt.tokens.RefreshToken.for_user(user)
         refresh['token_version'] = user.token_version
         access_token = refresh.access_token
+
         return rest_framework.response.Response(
             {'access': str(access_token), 'refresh': str(refresh)},
             status=rest_framework.status.HTTP_200_OK,
@@ -51,11 +53,10 @@ class SignInView(
     serializer_class = user.serializers.SignInSerializer
 
     def post(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
 
         try:
+            serializer = self.get_serializer(data=request.data)
             serializer.is_valid(raise_exception=True)
-            response = super().post(request, *args, **kwargs)
         except (
             rest_framework.serializers.ValidationError,
             rest_framework_simplejwt.exceptions.TokenError,
@@ -65,7 +66,12 @@ class SignInView(
 
             raise rest_framework_simplejwt.exceptions.InvalidToken(str(e))
 
+        response_data = {
+            'access': serializer.validated_data['access'],
+            'refresh': serializer.validated_data['refresh'],
+        }
+
         return rest_framework.response.Response(
-            response,
+            response_data,
             status=rest_framework.status.HTTP_200_OK,
         )


### PR DESCRIPTION
- Now the token version is increased during registration.

- Now the token version is not visible to the user and is left only on the server side.

- Add a test that checks the invalidation of the token received during registration after authentication.

- Simplify validate method in SignInSerializer.