### PR TITLE
feat(business): Add endpoint GET api/business/promo/list.

### DIFF
--- a/promo_code/business/pagination.py
+++ b/promo_code/business/pagination.py
@@ -1,0 +1,37 @@
+import rest_framework.exceptions
+import rest_framework.pagination
+import rest_framework.response
+
+
+class CustomLimitOffsetPagination(
+    rest_framework.pagination.LimitOffsetPagination,
+):
+    default_limit = 10
+    max_limit = 100
+
+    def get_limit(self, request):
+        param_limit = request.query_params.get(self.limit_query_param)
+        if param_limit is not None:
+            try:
+                limit = int(param_limit)
+                if limit < 0:
+                    raise rest_framework.exceptions.ValidationError(
+                        'Limit cannot be negative.',
+                    )
+
+                if limit == 0:
+                    return 0
+
+                if self.max_limit:
+                    return min(limit, self.max_limit)
+
+                return limit
+            except (TypeError, ValueError):
+                pass
+
+        return self.default_limit
+
+    def get_paginated_response(self, data):
+        response = rest_framework.response.Response(data)
+        response.headers['X-Total-Count'] = str(self.count)
+        return response

--- a/promo_code/business/urls.py
+++ b/promo_code/business/urls.py
@@ -26,4 +26,9 @@ urlpatterns = [
         business.views.PromoCreateView.as_view(),
         name='promo-create',
     ),
+    django.urls.path(
+        'promo/list',
+        business.views.CompanyPromoListView.as_view(),
+        name='company-promo-list',
+    ),
 ]


### PR DESCRIPTION
- Add endpoint Add GET api/business/promo/list to view company promo codes by various filters
- Endpoint GET api/business/promo/list, available only for authenticated companies
- Add filtering by ISO 3166-1 alpha-2 country codes (case-insensitive)
- Support sorting by active_from/active_until dates (descending order)
- Add custom pagination with X-Total-Count header
- Validate query parameters (country codes and sort_by values)
- Handle multiple country parameters in both comma-separated and repeated formats