### PR TITLE
fix(business): Correct validation for UNIQUE promo updates

### DIFF
--- a/promo_code/business/serializers.py
+++ b/promo_code/business/serializers.py
@@ -534,15 +534,6 @@ class PromoDetailSerializer(rest_framework.serializers.ModelSerializer):
                 )
 
         elif mode == business_models.Promo.MODE_UNIQUE:
-            if not promo_unique:
-                raise rest_framework.serializers.ValidationError(
-                    {
-                        'promo_unique': (
-                            'This field is required for UNIQUE mode.'
-                        ),
-                    },
-                )
-
             if promo_common is not None:
                 raise rest_framework.serializers.ValidationError(
                     {


### PR DESCRIPTION
PATCH requests to update fields (like description or image_url) on promos with mode='UNIQUE' failed. The validator incorrectly required the `promo_unique` field to be present in the input data.

This commit removes the erroneous check for `promo_unique` presence from the `PromoDetailSerializer.validate` method when handling updates for UNIQUE promos, allowing partial updates to proceed correctly.