### PR TITLE
refactor(business): DRY‑up promo validation & optimize creation logic

### DIFF
--- a/promo_code/business/managers.py
+++ b/promo_code/business/managers.py
@@ -1,0 +1,53 @@
+import django.contrib.auth.models
+import django.db.models
+
+import business.models
+
+
+class CompanyManager(django.contrib.auth.models.BaseUserManager):
+    def create_company(self, email, name, password=None, **extra_fields):
+        if not email:
+            raise ValueError('The Email must be set')
+
+        email = self.normalize_email(email)
+        company = self.model(
+            email=email,
+            name=name,
+            **extra_fields,
+        )
+        company.set_password(password)
+        company.save(using=self._db)
+        return company
+
+
+class PromoManager(django.db.models.Manager):
+    @django.db.transaction.atomic
+    def create_promo(
+        self,
+        user,
+        target_data,
+        promo_common,
+        promo_unique,
+        **kwargs,
+    ):
+        promo = self.create(
+            company=user,
+            target=target_data,
+            **kwargs,
+        )
+
+        if promo.mode == business.models.Promo.MODE_COMMON:
+            promo.promo_common = promo_common
+            promo.save(update_fields=['promo_common'])
+        elif promo.mode == business.models.Promo.MODE_UNIQUE and promo_unique:
+            self._create_unique_codes(promo, promo_unique)
+
+        return promo
+
+    def _create_unique_codes(self, promo, codes):
+        business.models.PromoCode.objects.bulk_create(
+            [
+                business.models.PromoCode(promo=promo, code=code)
+                for code in codes
+            ],
+        )

--- a/promo_code/business/models.py
+++ b/promo_code/business/models.py
@@ -3,21 +3,7 @@ import uuid
 import django.contrib.auth.models
 import django.db.models
 
-
-class CompanyManager(django.contrib.auth.models.BaseUserManager):
-    def create_company(self, email, name, password=None, **extra_fields):
-        if not email:
-            raise ValueError('The Email must be set')
-
-        email = self.normalize_email(email)
-        company = self.model(
-            email=email,
-            name=name,
-            **extra_fields,
-        )
-        company.set_password(password)
-        company.save(using=self._db)
-        return company
+import business.managers
 
 
 class Company(django.contrib.auth.models.AbstractBaseUser):
@@ -37,7 +23,7 @@ class Company(django.contrib.auth.models.AbstractBaseUser):
     created_at = django.db.models.DateTimeField(auto_now_add=True)
     is_active = django.db.models.BooleanField(default=True)
 
-    objects = CompanyManager()
+    objects = business.managers.CompanyManager()
 
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['name']
@@ -86,6 +72,8 @@ class Promo(django.db.models.Model):
     active = django.db.models.BooleanField(default=True)
 
     created_at = django.db.models.DateTimeField(auto_now_add=True)
+
+    objects = business.managers.PromoManager()
 
     def __str__(self):
         return f'Promo {self.id} ({self.mode})'

--- a/promo_code/business/tests/promocodes/operations/test_detail.py
+++ b/promo_code/business/tests/promocodes/operations/test_detail.py
@@ -45,7 +45,6 @@ class TestPromoDetail(business.tests.promocodes.base.BasePromoTestCase):
         cls.promo2_id = response2.data['id']
 
     def test_get_promo_company1(self):
-
         promo_detail_url = django.urls.reverse(
             'api-business:promo-detail',
             kwargs={'id': self.__class__.promo1_id},

--- a/promo_code/business/tests/promocodes/validations/test_create_validation.py
+++ b/promo_code/business/tests/promocodes/validations/test_create_validation.py
@@ -7,7 +7,6 @@ import business.tests.promocodes.base
 class TestPromoCreate(
     business.tests.promocodes.base.BasePromoTestCase,
 ):
-
     def setUp(self):
         super().setUp()
         self.client.credentials(

--- a/promo_code/business/tests/promocodes/validations/test_detail_validation.py
+++ b/promo_code/business/tests/promocodes/validations/test_detail_validation.py
@@ -5,7 +5,6 @@ import business.tests.promocodes.base
 
 
 class TestPromoDetail(business.tests.promocodes.base.BasePromoTestCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
- Apply DRY: extract shared validation rules into dedicated `PromoValidator` to eliminate duplication between `PromoCreateSerializer` and `PromoDetailSerializer`
- Implement atomic promo creation via `PromoManager.create_promo()` using `@transaction.atomic` for full rollback on error
- Move custom model managers into `managers.py` for cleaner structure