### PR TITLE
feat(promo): Refactor CompanyPromoDetailView to RetrieveUpdateAPIView

### DIFF
--- a/promo_code/business/managers.py
+++ b/promo_code/business/managers.py
@@ -22,6 +22,33 @@ class CompanyManager(django.contrib.auth.models.BaseUserManager):
 
 
 class PromoManager(django.db.models.Manager):
+    def get_queryset(self):
+        return super().get_queryset()
+
+    def with_related(self):
+        return (
+            self.select_related('company')
+            .prefetch_related('unique_codes')
+            .only(
+                'id',
+                'company',
+                'description',
+                'image_url',
+                'target',
+                'max_count',
+                'active_from',
+                'active_until',
+                'mode',
+                'promo_common',
+                'created_at',
+                'company__id',
+                'company__name',
+            )
+        )
+
+    def for_company(self, user):
+        return self.with_related().filter(company=user)
+
     @django.db.transaction.atomic
     def create_promo(
         self,

--- a/promo_code/business/pagination.py
+++ b/promo_code/business/pagination.py
@@ -1,4 +1,3 @@
-import rest_framework.exceptions
 import rest_framework.pagination
 import rest_framework.response
 

--- a/promo_code/business/permissions.py
+++ b/promo_code/business/permissions.py
@@ -5,4 +5,14 @@ import business.models
 
 class IsCompanyUser(rest_framework.permissions.BasePermission):
     def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+
         return isinstance(request.user, business.models.Company)
+
+
+class IsPromoOwner(rest_framework.permissions.BasePermission):
+    message = 'The promo code does not belong to this company.'
+
+    def has_object_permission(self, request, view, obj):
+        return getattr(obj, 'company_id', None) == request.user.id


### PR DESCRIPTION
Refactor CompanyPromoDetailView from a generic APIView to DRF’s RetrieveUpdateAPIView in order to leverage built-in retrieve/update behavior and simplify the implementation.

Key changes:
- Use `RetrieveUpdateAPIView` as the base class to get object lookup, serialization, validation and response handling for free
- Remove manual `get()` and `patch()` methods
- Add `business.permissions.IsPromoOwner` to `permission_classes` for declarative authorization
- Define `queryset = Promo.objects.with_related().only(...).for_company()` on the view to centralize and optimize data access
- Implement `with_related()` and `for_company(user)` on the Promo queryset/manager for efficient prefetching and filtering
- Drop unused imports and old helper code

This change reduces boilerplate, improves consistency with DRF idioms, and makes permission checks and queryset logic easier to maintain.