### PR TITLE
feat: Add User Profile endpoint with GET and PATCH support

### DIFF
--- a/promo_code/user/urls.py
+++ b/promo_code/user/urls.py
@@ -22,4 +22,9 @@ urlpatterns = [
         rest_framework_simplejwt.views.TokenRefreshView.as_view(),
         name='user-token-refresh',
     ),
+    django.urls.path(
+        'profile',
+        user.views.UserProfileView.as_view(),
+        name='user-profile',
+    ),
 ]

--- a/promo_code/user/views.py
+++ b/promo_code/user/views.py
@@ -1,9 +1,11 @@
 import rest_framework.generics
+import rest_framework.permissions
 import rest_framework.response
 import rest_framework.status
 import rest_framework_simplejwt.tokens
 import rest_framework_simplejwt.views
 
+import user.models
 import user.serializers
 
 
@@ -37,3 +39,21 @@ class UserSignInView(
     rest_framework_simplejwt.views.TokenObtainPairView,
 ):
     serializer_class = user.serializers.SignInSerializer
+
+
+class UserProfileView(
+    rest_framework.generics.RetrieveUpdateAPIView,
+):
+    """
+    Retrieve (GET) and partially update (PATCH)
+    detailed user profile information.
+    """
+    http_method_names = ['get', 'patch', 'options', 'head']
+    serializer_class = user.serializers.UserProfileSerializer
+    permission_classes = [rest_framework.permissions.IsAuthenticated]
+
+    def get_object(self):
+        return self.request.user
+
+    def patch(self, request, *args, **kwargs):
+        return self.partial_update(request, *args, **kwargs)


### PR DESCRIPTION
- Implemented `UserProfileSerializer` to handle partial updates:
  - Omits `avatar_url` from output when it’s empty or null
  - Hashes new passwords with `set_password()` without incrementing `token_version` (tokens remain valid)
- Created `UserProfileView` (RetrieveUpdateAPIView) with `IsAuthenticated` permission
  - `GET /user/profile` returns current user’s data
  - `PATCH /user/profile` applies only provided fields
- Registered route `path('user/profile', UserProfileView.as_view())`