### PR TITLE
feat(user): Add GET api/user/promo/{id} endpoint

### DIFF
--- a/promo_code/user/serializers.py
+++ b/promo_code/user/serializers.py
@@ -9,6 +9,7 @@ import rest_framework_simplejwt.serializers
 import rest_framework_simplejwt.token_blacklist.models as tb_models
 import rest_framework_simplejwt.tokens
 
+import business.models
 import user.constants
 import user.models
 import user.validators
@@ -244,3 +245,64 @@ class UserProfileSerializer(rest_framework.serializers.ModelSerializer):
         if not instance.avatar_url:
             data.pop('avatar_url', None)
         return data
+
+
+class UserPromoDetailSerializer(rest_framework.serializers.ModelSerializer):
+    """
+    Serializer for detailed promo-code information
+    (without revealing the code value).
+    The output format matches the given example.
+    """
+
+    promo_id = rest_framework.serializers.UUIDField(
+        source='id',
+        read_only=True,
+    )
+    company_id = rest_framework.serializers.UUIDField(
+        source='company.id',
+        read_only=True,
+    )
+    company_name = rest_framework.serializers.CharField(
+        source='company.name',
+        read_only=True,
+    )
+    active = rest_framework.serializers.BooleanField(
+        source='is_active',
+        read_only=True,
+    )
+    is_activated_by_user = rest_framework.serializers.SerializerMethodField()
+    like_count = rest_framework.serializers.SerializerMethodField()
+    is_liked_by_user = rest_framework.serializers.SerializerMethodField()
+    comment_count = rest_framework.serializers.SerializerMethodField()
+
+    class Meta:
+        model = business.models.Promo
+        fields = (
+            'promo_id',
+            'company_id',
+            'company_name',
+            'description',
+            'image_url',
+            'active',
+            'is_activated_by_user',
+            'like_count',
+            'is_liked_by_user',
+            'comment_count',
+        )
+        read_only_fields = fields
+
+    def get_is_activated_by_user(self, obj) -> bool:
+        # TODO:
+        return False
+
+    def get_like_count(self, obj) -> int:
+        # TODO:
+        return 0
+
+    def get_is_liked_by_user(self, obj) -> bool:
+        # TODO:
+        return False
+
+    def get_comment_count(self, obj) -> int:
+        # TODO:
+        return 0

--- a/promo_code/user/urls.py
+++ b/promo_code/user/urls.py
@@ -27,4 +27,9 @@ urlpatterns = [
         user.views.UserProfileView.as_view(),
         name='user-profile',
     ),
+    django.urls.path(
+        'promo/<uuid:id>/',
+        user.views.UserPromoDetailView.as_view(),
+        name='user-promo-detail',
+    ),
 ]

--- a/promo_code/user/views.py
+++ b/promo_code/user/views.py
@@ -5,6 +5,8 @@ import rest_framework.status
 import rest_framework_simplejwt.tokens
 import rest_framework_simplejwt.views
 
+import business.constants
+import business.models
 import user.models
 import user.serializers
 
@@ -48,6 +50,7 @@ class UserProfileView(
     Retrieve (GET) and partially update (PATCH)
     detailed user profile information.
     """
+
     http_method_names = ['get', 'patch', 'options', 'head']
     serializer_class = user.serializers.UserProfileSerializer
     permission_classes = [rest_framework.permissions.IsAuthenticated]
@@ -57,3 +60,36 @@ class UserProfileView(
 
     def patch(self, request, *args, **kwargs):
         return self.partial_update(request, *args, **kwargs)
+
+
+class UserPromoDetailView(rest_framework.generics.RetrieveAPIView):
+    """
+    Retrieve (GET) information about the promo without receiving a promo code.
+    """
+
+    queryset = (
+        business.models.Promo.objects.select_related('company')
+        .prefetch_related(
+            'unique_codes',
+        )
+        .only(
+            'id',
+            'company__id',
+            'company__name',
+            'description',
+            'image_url',
+            'active',
+            'active_from',
+            'active_until',
+            'mode',
+            'used_count',
+        )
+    )
+
+    serializer_class = user.serializers.UserPromoDetailSerializer
+
+    permission_classes = [
+        rest_framework.permissions.IsAuthenticated,
+    ]
+
+    lookup_field = 'id'


### PR DESCRIPTION
Implements a read-only endpoint for authenticated users to retrieve details of a specific promo code by its UUID.

- Does not expose the actual promo code value.
- Does not activate the promo code.
- Includes promo description, company info, image, active status.