### PR TITLE
test: Add tests for /api/user/feed endpoint

### DIFF
--- a/promo_code/user/serializers.py
+++ b/promo_code/user/serializers.py
@@ -297,6 +297,19 @@ class UserFeedQuerySerializer(rest_framework.serializers.Serializer):
 
         return attrs
 
+    def validate_category(self, value):
+        cotegory = self.initial_data.get('category')
+
+        if cotegory is None:
+            return value
+
+        if value == '':
+            raise rest_framework.exceptions.ValidationError(
+                'Invalid category format.',
+            )
+
+        return value
+
     def _validate_int_field(self, field_name, attrs, field_errors):
         value_str = self.initial_data.get(field_name)
         if value_str is None:

--- a/promo_code/user/tests/user/base.py
+++ b/promo_code/user/tests/user/base.py
@@ -14,6 +14,11 @@ class BaseUserTestCase(rest_framework.test.APITestCase):
         cls.user_signup_url = django.urls.reverse('api-user:user-sign-up')
         cls.user_signin_url = django.urls.reverse('api-user:user-sign-in')
         cls.user_profile_url = django.urls.reverse('api-user:user-profile')
+        cls.user_feed_url = django.urls.reverse('api-user:user-feed')
+
+        cls.company_signin_url = django.urls.reverse(
+            'api-business:company-sign-in',
+        )
         cls.promo_list_create_url = django.urls.reverse(
             'api-business:promo-list-create',
         )
@@ -28,9 +33,7 @@ class BaseUserTestCase(rest_framework.test.APITestCase):
             email=company1_data['email'],
         )
         response1 = cls.client.post(
-            django.urls.reverse(
-                'api-business:company-sign-in',
-            ),
+            cls.company_signin_url,
             {
                 'email': company1_data['email'],
                 'password': company1_data['password'],
@@ -38,6 +41,28 @@ class BaseUserTestCase(rest_framework.test.APITestCase):
             format='json',
         )
         cls.company1_token = response1.data['access']
+        cls.company1_name = cls.company1.name
+
+        company2_data = {
+            'name': 'Synergy Solutions Co.',
+            'email': 'company2@example.com',
+            'password': 'AnotherSecurePass456!',
+        }
+        business.models.Company.objects.create_company(**company2_data)
+
+        cls.company2 = business.models.Company.objects.get(
+            email=company2_data['email'],
+        )
+        response2 = cls.client.post(
+            cls.company_signin_url,
+            {
+                'email': company2_data['email'],
+                'password': company2_data['password'],
+            },
+            format='json',
+        )
+        cls.company2_token = response2.data['access']
+        cls.company2_name = cls.company2.name
 
     def tearDown(self):
         business.models.Company.objects.all().delete()
@@ -52,5 +77,12 @@ class BaseUserTestCase(rest_framework.test.APITestCase):
     def promo_detail_url(cls, promo_id):
         return django.urls.reverse(
             'api-user:user-promo-detail',
+            kwargs={'id': promo_id},
+        )
+
+    @classmethod
+    def get_promo_business_detail_url(cls, promo_id):
+        return django.urls.reverse(
+            'api-business:promo-detail',
             kwargs={'id': promo_id},
         )

--- a/promo_code/user/tests/user/operations/test_detail.py
+++ b/promo_code/user/tests/user/operations/test_detail.py
@@ -59,7 +59,12 @@ class TestUserPromoDetail(user.tests.user.base.BaseUserTestCase):
 
         promo_us = {
             'description': 'Gift sleeping mask with car loan application',
-            'target': {'age_from': 28, 'age_until': 50, 'country': 'us'},
+            'target': {
+                'age_from': 28,
+                'age_until': 50,
+                'country': 'us',
+                'categories': ['cars'],
+            },
             'max_count': 1,
             'active_from': '2025-01-01',
             'active_until': '2028-12-30',

--- a/promo_code/user/tests/user/operations/test_feed.py
+++ b/promo_code/user/tests/user/operations/test_feed.py
@@ -1,0 +1,683 @@
+import datetime
+
+import rest_framework.status
+
+import user.tests.user.base
+
+
+class TestUserPromoFeed(user.tests.user.base.BaseUserTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        user1_payload = {
+            'name': 'Steve',
+            'surname': 'Wozniak',
+            'email': 'creator1@apple.com',
+            'password': 'WhoLiveSInCalifornia2000!',
+            'other': {'age': 60, 'country': 'gb'},
+        }
+        resp = cls.client.post(
+            cls.user_signup_url,
+            user1_payload,
+            format='json',
+        )
+
+        cls.user1_token = resp.data['access']
+
+        user2_payload = {
+            'name': 'Mike',
+            'surname': 'Bloomberg',
+            'email': 'mike@bloomberg.com',
+            'password': 'WhoLiveSInCalifornia2000!',
+            'other': {'age': 15, 'country': 'us'},
+        }
+        resp = cls.client.post(
+            cls.user_signup_url,
+            user2_payload,
+            format='json',
+        )
+
+        cls.user2_token = resp.data['access']
+
+        user3_payload = {
+            'name': 'Yefim',
+            'surname': 'Dinitz',
+            'email': 'algo@prog.ru',
+            'password': 'HardPASSword1!',
+            'other': {'age': 40, 'country': 'LU'},
+        }
+        resp = cls.client.post(
+            cls.user_signup_url,
+            user3_payload,
+            format='json',
+        )
+
+        cls.user3_token = resp.data['access']
+
+        user4_payload = {
+            'name': 'Leslie',
+            'surname': 'Lamport',
+            'email': 'leslie@lamport.com',
+            'password': 'Everyth1ngIsDistributed!',
+            'other': {'age': 80, 'country': 'sg'},
+        }
+        resp = cls.client.post(
+            cls.user_signup_url,
+            user4_payload,
+            format='json',
+        )
+
+        cls.user4_token = resp.data['access']
+
+        cls.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + cls.company1_token,
+        )
+
+        today = datetime.date.today()
+
+        promo1 = {
+            'description': 'Active COMMON promo, no target',
+            'target': {},
+            'max_count': 10,
+            'active_from': '2025-01-10',
+            'mode': 'COMMON',
+            'promo_common': 'sale-10',
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo1,
+            format='json',
+        )
+
+        cls.promo1_id = resp.data['id']
+
+        promo2 = {
+            'description': 'Active COMMON promo for fr',
+            'target': {
+                'country': 'fr',
+                'categories': ['ios', 'tbank', 'CATS'],
+            },
+            'max_count': 6,
+            'active_from': '2023-01-10',
+            'mode': 'COMMON',
+            'promo_common': 'sale-10',
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo2,
+            format='json',
+        )
+
+        cls.promo2_id = resp.data['id']
+
+        promo3 = {
+            'description': 'Inactive COMMON promo for us, age 13+',
+            'target': {'country': 'us', 'age_from': 13, 'categories': ['ios']},
+            'max_count': 100000,
+            'active_until': '2025-01-10',
+            'mode': 'COMMON',
+            'promo_common': 'sale-30',
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo3,
+            format='json',
+        )
+        cls.promo3_id = resp.data['id']
+
+        promo4 = {
+            'description': 'Active UNIQUE promo for lu, age 20-60',
+            'target': {
+                'country': 'lu',
+                'age_from': 20,
+                'age_until': 60,
+                'categories': ['television'],
+            },
+            'max_count': 1,
+            'active_from': (today - datetime.timedelta(days=1)).strftime(
+                '%Y-%m-%d',
+            ),
+            'active_until': '2055-01-10',
+            'mode': 'UNIQUE',
+            'promo_unique': ['dream', 'of:', 'californication'],
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo4,
+            format='json',
+        )
+        cls.promo4_id = resp.data['id']
+
+        promo5 = {
+            'description': 'Active COMMON promo for lu, age up to 50',
+            'target': {'country': 'lu', 'age_until': 50},
+            'max_count': 1000,
+            'active_from': '2023-01-10',
+            'active_until': '2080-05-30',
+            'mode': 'COMMON',
+            'promo_common': 'sale-10',
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo5,
+            format='json',
+        )
+        cls.promo5_id = resp.data['id']
+
+        cls.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + cls.company2_token,
+        )
+
+        promo6 = {
+            'description': 'Inactive COMMON promo for fr, age 5-90',
+            'target': {
+                'country': 'fr',
+                'age_from': 5,
+                'age_until': 90,
+                'categories': ['Television'],
+            },
+            'max_count': 1,
+            'active_from': '2040-12-08',
+            'mode': 'COMMON',
+            'promo_common': 'sale-10',
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo6,
+            format='json',
+        )
+        cls.promo6_id = resp.data['id']
+
+        promo7 = {
+            'description': 'Active COMMON promo for lu, age 16+',
+            'target': {
+                'country': 'lu',
+                'age_from': 16,
+                'categories': ['Television'],
+            },
+            'max_count': 1,
+            'active_from': (today - datetime.timedelta(days=1)).strftime(
+                '%Y-%m-%d',
+            ),
+            'mode': 'COMMON',
+            'promo_common': 'sale-10',
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo7,
+            format='json',
+        )
+        cls.promo7_id = resp.data['id']
+
+        promo8 = {
+            'description': 'Inactive COMMON promo for all, max_count 0',
+            'target': {'categories': ['TELEVISION']},
+            'max_count': 0,
+            'mode': 'COMMON',
+            'promo_common': 'sale-10',
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo8,
+            format='json',
+        )
+        cls.promo8_id = resp.data['id']
+
+        promo9 = {
+            'description': 'Active COMMON promo for lu, age up to 70',
+            'target': {'country': 'lu', 'age_until': 70},
+            'max_count': 1,
+            'active_from': (today - datetime.timedelta(days=1)).strftime(
+                '%Y-%m-%d',
+            ),
+            'active_until': '2099-08-10',
+            'mode': 'COMMON',
+            'promo_common': 'sale-10',
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo9,
+            format='json',
+        )
+        cls.promo9_id = resp.data['id']
+
+        promo10 = {
+            'description': 'Active COMMON promo for KZ',
+            'target': {'country': 'kz'},
+            'max_count': 10,
+            'active_from': '2025-01-10',
+            'mode': 'COMMON',
+            'promo_common': 'sale-10',
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo10,
+            format='json',
+        )
+        cls.promo10_id = resp.data['id']
+
+        promo11 = {
+            'description': 'Active COMMON promo for SG',
+            'target': {'country': 'sg'},
+            'max_count': 1000,
+            'active_from': '2023-01-10',
+            'mode': 'COMMON',
+            'promo_common': 'sale-10',
+        }
+        resp = cls.client.post(
+            cls.promo_list_create_url,
+            promo11,
+            format='json',
+        )
+        cls.promo11_id = resp.data['id']
+
+        cls.client.credentials()
+
+    def test_user1_gb_60_get_all_promos(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user1_token,
+        )
+        response = self.client.get(self.user_feed_url, format='json')
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '2')
+
+        expected_data = [
+            {
+                'promo_id': self.promo8_id,
+                'company_name': self.company2_name,
+                'active': False,
+            },
+            {
+                'promo_id': self.promo1_id,
+                'company_name': self.company1_name,
+                'active': True,
+            },
+        ]
+        actual_data = [
+            {
+                'promo_id': item['promo_id'],
+                'company_name': item['company_name'],
+                'active': item['active'],
+            }
+            for item in response.data
+        ]
+        self.assertEqual(actual_data, expected_data)
+
+    def test_user2_us_15_get_all_promos(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user2_token,
+        )
+        response = self.client.get(self.user_feed_url, format='json')
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '3')
+
+        expected_data = [
+            {
+                'promo_id': self.promo8_id,
+                'company_name': self.company2_name,
+                'active': False,
+            },
+            {
+                'promo_id': self.promo3_id,
+                'company_name': self.company1_name,
+                'active': False,
+            },
+            {
+                'promo_id': self.promo1_id,
+                'company_name': self.company1_name,
+                'active': True,
+            },
+        ]
+        actual_data = [
+            {
+                'promo_id': item['promo_id'],
+                'company_name': item['company_name'],
+                'active': item['active'],
+            }
+            for item in response.data
+        ]
+        self.assertEqual(actual_data, expected_data)
+
+    def test_user3_lu_40_get_all_promos(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user3_token,
+        )
+        response = self.client.get(self.user_feed_url, format='json')
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '6')
+
+        expected_data = [
+            {
+                'promo_id': self.promo9_id,
+                'company_name': self.company2_name,
+                'active': True,
+            },
+            {
+                'promo_id': self.promo8_id,
+                'company_name': self.company2_name,
+                'active': False,
+            },
+            {
+                'promo_id': self.promo7_id,
+                'company_name': self.company2_name,
+                'active': True,
+            },
+            {
+                'promo_id': self.promo5_id,
+                'company_name': self.company1_name,
+                'active': True,
+            },
+            {
+                'promo_id': self.promo4_id,
+                'company_name': self.company1_name,
+                'active': True,
+            },
+            {
+                'promo_id': self.promo1_id,
+                'company_name': self.company1_name,
+                'active': True,
+            },
+        ]
+        actual_data = [
+            {
+                'promo_id': item['promo_id'],
+                'company_name': item['company_name'],
+                'active': item['active'],
+            }
+            for item in response.data
+        ]
+        self.assertEqual(actual_data, expected_data)
+
+    def test_user3_lu_40_get_all_promos_pagination_offset2_limit3(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user3_token,
+        )
+        response = self.client.get(
+            self.user_feed_url,
+            {'offset': 2, 'limit': 3},
+            format='json',
+        )
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '6')
+
+        expected_ids = [self.promo7_id, self.promo5_id, self.promo4_id]
+        actual_ids = [item['promo_id'] for item in response.data]
+        self.assertEqual(actual_ids, expected_ids)
+
+    def test_user3_lu_40_get_all_promos_pagination_offset10_limit2(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user3_token,
+        )
+        response = self.client.get(
+            self.user_feed_url,
+            {'offset': 10, 'limit': 2},
+            format='json',
+        )
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '6')
+        self.assertEqual(response.data, [])
+
+    def test_user3_lu_40_get_all_promos_pagination_offset3_limit1(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user3_token,
+        )
+        response = self.client.get(
+            self.user_feed_url,
+            {'offset': 3, 'limit': 1},
+            format='json',
+        )
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '6')
+
+        expected_ids = [self.promo5_id]
+        actual_ids = [item['promo_id'] for item in response.data]
+        self.assertEqual(actual_ids, expected_ids)
+
+    def test_user3_lu_40_get_active_true_promos(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user3_token,
+        )
+        response = self.client.get(
+            self.user_feed_url,
+            {'active': 'true'},
+            format='json',
+        )
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '5')
+
+        expected_ids = [
+            self.promo9_id,
+            self.promo7_id,
+            self.promo5_id,
+            self.promo4_id,
+            self.promo1_id,
+        ]
+        actual_ids = [item['promo_id'] for item in response.data]
+        self.assertCountEqual(
+            actual_ids,
+            expected_ids,
+        )
+
+    def test_user3_lu_40_get_active_true_promos_pagination_offset2_limit2(
+        self,
+    ):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user3_token,
+        )
+        response = self.client.get(
+            self.user_feed_url,
+            {'active': 'true', 'limit': 2, 'offset': 2},
+            format='json',
+        )
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '5')
+
+        expected_ids = [self.promo5_id, self.promo4_id]
+        actual_ids = [item['promo_id'] for item in response.data]
+        self.assertEqual(
+            actual_ids,
+            expected_ids,
+        )
+
+    def test_user3_lu_40_get_active_false_promos(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user3_token,
+        )
+        response = self.client.get(
+            self.user_feed_url,
+            {'active': 'false'},
+            format='json',
+        )
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '1')
+
+        expected_ids = [self.promo8_id]
+        actual_ids = [item['promo_id'] for item in response.data]
+        self.assertEqual(actual_ids, expected_ids)
+
+    def test_user3_lu_40_get_promos_by_category_television_mixed_case_query(
+        self,
+    ):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user3_token,
+        )
+        response = self.client.get(
+            self.user_feed_url,
+            {'category': 'televiSION'},
+            format='json',
+        )
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '3')
+
+        expected_ids = [
+            self.promo8_id,
+            self.promo7_id,
+            self.promo4_id,
+        ]
+        actual_ids = [item['promo_id'] for item in response.data]
+        self.assertCountEqual(
+            actual_ids,
+            expected_ids,
+        )
+
+    def test_user3_lu_40_get_active_true_promos_by_category_television(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user3_token,
+        )
+        response = self.client.get(
+            self.user_feed_url,
+            {'category': 'television', 'active': 'true'},
+            format='json',
+        )
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '2')
+
+        expected_ids = [
+            self.promo7_id,
+            self.promo4_id,
+        ]
+        actual_ids = [item['promo_id'] for item in response.data]
+        self.assertCountEqual(actual_ids, expected_ids)
+
+    def test_user3_lu_40_get_promos_by_non_existent_category(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user3_token,
+        )
+        response = self.client.get(
+            self.user_feed_url,
+            {'category': 'non-exist-category'},
+            format='json',
+        )
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response['X-Total-Count'], '0')
+        self.assertEqual(response.data, [])
+
+    def test_user4_sg_80_get_all_promos(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user4_token,
+        )
+        response = self.client.get(self.user_feed_url, format='json')
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response.headers['X-Total-Count'], '3')
+
+        data = response.data
+        self.assertEqual(len(data), 3)
+        self.assertEqual(data[0]['promo_id'], self.promo11_id)
+        self.assertTrue(data[0]['active'])
+        self.assertEqual(data[1]['promo_id'], self.promo8_id)
+        self.assertEqual(data[2]['promo_id'], self.promo1_id)
+
+    def test_user4_sg_80_get_all_promos_after_edit(self):
+        # WARNING: this test globally changes the 'active' status of promo11
+        # for all subsequent tests
+
+        # Company edits promo11 to inactive
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.company2_token,
+        )
+        url = self.get_promo_business_detail_url(self.promo11_id)
+        patch_data = {'active_until': '2024-08-10'}
+        response = self.client.patch(url, patch_data, format='json')
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user4_token,
+        )
+        response = self.client.get(self.user_feed_url, format='json')
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_200_OK,
+        )
+        for item in response.data:
+            self.assertNotIn('promo_common', item)
+            self.assertNotIn('promo_unique', item)
+        self.assertEqual(response.headers['X-Total-Count'], '3')
+
+        data = response.data
+        self.assertEqual(len(data), 3)
+        self.assertEqual(data[0]['promo_id'], self.promo11_id)
+        self.assertFalse(data[0]['active'])
+        self.assertEqual(data[1]['promo_id'], self.promo8_id)
+        self.assertEqual(data[2]['promo_id'], self.promo1_id)

--- a/promo_code/user/tests/user/validations/test_feed_validation.py
+++ b/promo_code/user/tests/user/validations/test_feed_validation.py
@@ -1,0 +1,111 @@
+import parameterized
+import rest_framework.status
+import rest_framework.test
+
+import user.tests.user.base
+
+
+class TestUserPromoFeed(
+    user.tests.user.base.BaseUserTestCase,
+):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        user1_payload = {
+            'name': 'Steve',
+            'surname': 'Wozniak',
+            'email': 'creator1@apple.com',
+            'password': 'WhoLiveSInCalifornia2000!',
+            'other': {'age': 60, 'country': 'gb'},
+        }
+        resp = cls.client.post(
+            cls.user_signup_url,
+            user1_payload,
+            format='json',
+        )
+
+        cls.user1_token = resp.data['access']
+        cls.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + cls.user1_token,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.user1_token,
+        )
+
+    def test_get_promos_without_token(self):
+        self.client.credentials()
+        client = rest_framework.test.APIClient()
+        response = client.get(self.user_feed_url)
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_401_UNAUTHORIZED,
+        )
+
+    @parameterized.parameterized.expand(
+        [
+            (
+                'invalid_category_too_short',
+                {'category': 'A'},
+            ),
+            (
+                'invalid_category_too_long',
+                {'category': 'averylongcategorynamethatexceedstwenty'},
+            ),
+            (
+                'invalid_category_empty_string',
+                {'category': ''},
+            ),
+            (
+                'unexpected_parameter',
+                {'unexpected': 'value'},
+            ),
+            (
+                'combined_invalid_parameters',
+                {
+                    'category': 'A',
+                    'limit': -1,
+                    'sort_by': 'non_existing_field',
+                },
+            ),
+            (
+                'non-boolean_active_format',
+                {'active': 'abc'},
+            ),
+            (
+                'non-boolean_active_format_2',
+                {'active': 123},
+            ),
+            (
+                'non-boolean_active_format_3',
+                {'active': 1.5},
+            ),
+        ],
+    )
+    def test_invalid_query_string_parameters(self, _, params):
+        response = self.client.get(self.user_feed_url, params)
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_400_BAD_REQUEST,
+        )
+
+    @parameterized.parameterized.expand(
+        [
+            ('invalid_limit_format', {'limit': 'france'}),
+            ('invalid_offset_format', {'offset': 'france'}),
+            ('negative_offset', {'offset': -5}),
+            ('negative_limit', {'limit': -5}),
+            ('invalid_float_limit', {'limit': 5.5}),
+            ('invalid_float_offset', {'offset': 3.5}),
+            ('empty_string_limit', {'limit': ''}),
+            ('empty_string_offset', {'offset': ''}),
+        ],
+    )
+    def test_invalid_numeric_parameters(self, _, params):
+        response = self.client.get(self.user_feed_url, params)
+        self.assertEqual(
+            response.status_code,
+            rest_framework.status.HTTP_400_BAD_REQUEST,
+        )


### PR DESCRIPTION
1.  Integration of comprehensive functional tests (`TestUserPromoFeed`) that verify core endpoint behaviors:
    - Accurate user-specific promo targeting based on age and country.
    - Correct dynamic calculation of promo 'active' status (considering dates, usage counts, and unique code availability).
    - Effective filtering via `active` (boolean) and `category` (case-insensitive) query parameters.
    - Proper pagination functionality using `limit` and `offset`, including `X-Total-Count` header validation.
    - Verification of response data structure, ensuring exclusion of sensitive promo code values.
    - Correct reflection of promo data updates (e.g., a promo becoming inactive after an edit) in the feed.

2.  Addition of new focused validation tests (`TestUserPromoFeed`) using parameterized inputs to cover edge cases and invalid requests:
    - Authentication checks, specifically ensuring `401 Unauthorized` for requests lacking a token.
    - Rigorous validation of query parameters (`limit`, `offset`, `category`, `active`):
        - Invalid data types and formats (e.g., non-numeric for `limit`/`offset`, non-boolean for `active`).
        - Values outside defined constraints (e.g., negative `limit`/`offset`, category string length violations). - Empty string inputs for parameters that require specific formats.
    - Rejection of requests containing unexpected or unsupported query parameters, returning a `400 Bad Request`.