### PR TITLE
feat: Add promo code statistics endpoint

### DIFF
--- a/promo_code/business/serializers.py
+++ b/promo_code/business/serializers.py
@@ -538,3 +538,17 @@ class PromoDetailSerializer(rest_framework.serializers.ModelSerializer):
             instance=self.instance,
         )
         return validator.validate()
+
+
+class CountryStatSerializer(rest_framework.serializers.Serializer):
+    """Serializer for activation statistics by country."""
+
+    country = rest_framework.serializers.CharField()
+    activations_count = rest_framework.serializers.IntegerField()
+
+
+class PromoStatSerializer(rest_framework.serializers.Serializer):
+    """Serializer for overall promo code statistics."""
+
+    activations_count = rest_framework.serializers.IntegerField()
+    countries = CountryStatSerializer(many=True)

--- a/promo_code/business/urls.py
+++ b/promo_code/business/urls.py
@@ -31,4 +31,9 @@ urlpatterns = [
         business.views.CompanyPromoDetailView.as_view(),
         name='promo-detail',
     ),
+    django.urls.path(
+        'promo/<uuid:id>/stat',
+        business.views.CompanyPromoStatAPIView.as_view(),
+        name='promo-statistics',
+    ),
 ]

--- a/promo_code/user/tests/user/base.py
+++ b/promo_code/user/tests/user/base.py
@@ -84,6 +84,7 @@ class BaseUserTestCase(rest_framework.test.APITestCase):
         user.models.PromoLike.objects.all().delete()
         user.models.User.objects.all().delete()
         tb_models.BlacklistedToken.objects.all().delete()
+        tb_models.OutstandingToken.objects.all().delete()
         django_redis.get_redis_connection('default').flushall()
         super().tearDown()
 


### PR DESCRIPTION
This commit introduces a new endpoint for retrieving activation statistics for a specific promo code.

- `GET /api/business/promo/{id}/stat`: Allows a company to view detailed statistics for their promo code, including the total number of activations and a breakdown of activations by country.

Key changes include:
- A `CompanyPromoStatAPIView` that handles the logic for retrieving and serializing the statistics.
- New `CountryStatSerializer` and `PromoStatSerializer` to structure the response data.
- A new URL pattern in `business/urls.py` to route to the new view.
- A fix in `BaseUserTestCase` to clear `OutstandingToken` after tests.