### PR TITLE
ci: Fix coverage reporting and update bages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,11 @@ DJANGO_SECRET_KEY=your_django_secret_key
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0
 
 POSTGRES_DATABASE=your_postgres_database_name
-POSTGRES_HOST=db
 POSTGRES_PASSWORD=your_postgres_password
-POSTGRES_PORT=5432
 POSTGRES_USERNAME=your_postgres_username
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+
 
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,10 @@ jobs:
       - name: Run tests and generate coverage report 🛡️
         run: >
           docker compose exec -T web sh -c
-          "cd promo_code && coverage run manage.py test && coverage xml"
+          "cd promo_code && coverage run --rcfile=.coveragerc manage.py test && coverage xml"
+        
+      - name: Copy coverage report from container 📂
+        run: docker compose cp web:/app/promo_code/coverage.xml ./coverage.xml
 
       - name: Upload coverage to Codecov 🚀
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           "cd promo_code && coverage run --rcfile=.coveragerc manage.py test && coverage xml"
         
       - name: Copy coverage report from container 📂
-        run: docker compose cp web:/app/promo_code/coverage.xml ./coverage.xml
+        run: docker compose cp web:/usr/src/app/promo_code/coverage.xml ./coverage.xml
 
       - name: Upload coverage to Codecov 🚀
         uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Promo Code API
 
-[![CI/CD](https://github.com/RandomProgramm3r/Promo-Code-API/actions/workflows/linting.yml/badge.svg)](https://github.com/RandomProgramm3r/Promo-Code-API/actions)
+[![CI/CD](https://github.com/RandomProgramm3r/Promo-Code-API/actions/workflows/ci.yml/badge.svg)](https://github.com/RandomProgramm3r/Promo-Code-API/actions)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![codecov](https://codecov.io/github/RandomProgramm3r/Promo-Code-API/graph/badge.svg?token=VNBK0FAU3Z)](https://codecov.io/github/RandomProgramm3r/Promo-Code-API)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Promo Code API
 
 [![CI/CD](https://github.com/RandomProgramm3r/Promo-Code-API/actions/workflows/ci.yml/badge.svg)](https://github.com/RandomProgramm3r/Promo-Code-API/actions)
+[![codecov](https://codecov.io/github/RandomProgramm3r/Promo-Code-API/branch/main/graph/badge.svg?token=VNBK0FAU3Z)](https://codecov.io/github/RandomProgramm3r/Promo-Code-API)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![codecov](https://codecov.io/github/RandomProgramm3r/Promo-Code-API/graph/badge.svg?token=VNBK0FAU3Z)](https://codecov.io/github/RandomProgramm3r/Promo-Code-API)
 
 The application provides an HTTP API for companies and end-users, is integrated with an external anti-fraud service, and uses PostgreSQL and Redis for data storage and caching.
 


### PR DESCRIPTION
This commit resolves issues with the CI workflow related to code coverage reporting.

- Explicitly specifies the coverage configuration file (`--rcfile=.coveragerc`) to ensure correct settings are applied during tests.
- Adds a step to copy the `coverage.xml` report from the Docker container to the host, making it available for the Codecov action.
 - Updates the CI status badge in the README to point to the correct workflow file.
 - Update Codecov badge URL.