### PR TITLE
fix(ci): Correct Codecov reporting and file discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run tests and generate coverage report 🛡️
         run: >
           docker compose exec -T web sh -c
-          "cd promo_code && coverage run --rcfile=.coveragerc manage.py test && coverage xml"
+          "coverage run --source='.' promo_code/manage.py test business core user && coverage xml -o promo_code/coverage.xml"
         
       - name: Copy coverage report from container 📂
         run: docker compose cp web:/usr/src/app/promo_code/coverage.xml ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run tests and generate coverage report 🛡️
         run: >
           docker compose exec -T web sh -c
-          "coverage run --source='.' promo_code/manage.py test business core user && coverage xml -o promo_code/coverage.xml"
+          "coverage run --rcfile=promo_code/.coveragerc --source='.' promo_code/manage.py test business core user && coverage xml -o promo_code/coverage.xml"
         
       - name: Copy coverage report from container 📂
         run: docker compose cp web:/usr/src/app/promo_code/coverage.xml ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,5 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          directory: promo_code 
           fail_ci_if_error: true


### PR DESCRIPTION
This commit resolves a critical issue where Codecov was reporting inaccurate coverage metrics due to missing source files. The CI workflow has been updated to ensure all relevant files are discovered and processed correctly.
Key changes:
- The `coverage run` command now explicitly specifies the source directory (`--source='.'`) and the target applications (`business`, `core`, `user`). This forces `coverage` to analyze all relevant files, not just those touched by tests, fixing the incorrect file and line counts in Codecov reports.
- The path to the `.coveragerc` configuration file is now correctly specified, ensuring custom settings are applied.
- The Codecov GitHub Action is now configured with the correct `directory` to locate the `coverage.xml` report.
- The entire test and coverage generation command has been streamlined for better clarity and reliability.